### PR TITLE
✅ Fix: Ajout dépendance Jakarta Annotations + ConfigManager avec @PostConstruct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <logback.version>1.4.11</logback.version>
         <junit.version>5.10.0</junit.version>
         <mockito.version>5.4.0</mockito.version>
+        <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
     </properties>
 
     <dependencies>
@@ -46,6 +47,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
             <version>${spring-boot.version}</version>
+        </dependency>
+        
+        <!-- Jakarta Annotations (pour @PostConstruct, @PreDestroy, etc.) -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.version}</version>
         </dependency>
         
         <!-- Jackson pour la manipulation JSON -->

--- a/src/main/java/com/angel/config/ConfigManager.java
+++ b/src/main/java/com/angel/config/ConfigManager.java
@@ -3,6 +3,7 @@ package com.angel.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import jakarta.annotation.PostConstruct;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,11 +26,22 @@ public class ConfigManager {
     @Value("${avatar.config.path:config/avatar.properties}")
     private String avatarConfigPath;
     
+    private boolean initialized = false;
+    
     /**
-     * Constructeur qui charge automatiquement les configurations.
+     * Constructeur par défaut.
      */
     public ConfigManager() {
+        // Le chargement se fait dans @PostConstruct après injection des valeurs
+    }
+    
+    /**
+     * Initialisation après injection des dépendances Spring.
+     */
+    @PostConstruct
+    public void init() {
         loadConfigurations();
+        initialized = true;
     }
     
     /**
@@ -37,8 +49,13 @@ public class ConfigManager {
      */
     private void loadConfigurations() {
         try {
-            // Charger la configuration principale de l'avatar
-            loadConfigFile("avatar", avatarConfigPath);
+            // Charger la configuration principale de l'avatar (si le chemin est défini)
+            if (avatarConfigPath != null && !avatarConfigPath.trim().isEmpty()) {
+                loadConfigFile("avatar", avatarConfigPath);
+            } else {
+                // Valeur par défaut si @Value n'est pas injecté
+                loadConfigFile("avatar", "config/avatar.properties");
+            }
             
             // Charger d'autres fichiers de configuration
             loadConfigFile("phoneme-viseme", "config/phoneme-viseme-mapping.properties");
@@ -58,6 +75,12 @@ public class ConfigManager {
      */
     private void loadConfigFile(String name, String path) {
         try {
+            if (path == null || path.trim().isEmpty()) {
+                LOGGER.log(Level.WARNING, "Chemin de configuration null ou vide pour: {0}", name);
+                configSources.put(name, new Properties());
+                return;
+            }
+            
             ClassPathResource resource = new ClassPathResource(path);
             if (resource.exists()) {
                 Properties props = new Properties();
@@ -68,9 +91,13 @@ public class ConfigManager {
                 }
             } else {
                 LOGGER.log(Level.WARNING, "Fichier de configuration non trouvé: {0}", path);
+                // Créer une configuration vide pour éviter les erreurs
+                configSources.put(name, new Properties());
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "Erreur lors du chargement de " + path, e);
+            // Créer une configuration vide pour éviter les erreurs
+            configSources.put(name, new Properties());
         }
     }
     
@@ -305,6 +332,14 @@ public class ConfigManager {
         stats.put("totalProperties", mergedConfig.size());
         stats.put("configSources", configSources.size());
         stats.put("sourceNames", configSources.keySet());
+        stats.put("initialized", initialized);
         return stats;
+    }
+    
+    /**
+     * Vérifie si le ConfigManager est initialisé.
+     */
+    public boolean isInitialized() {
+        return initialized;
     }
 }


### PR DESCRIPTION
## ✅ Solution propre : Ajout dépendance Jakarta Annotations + ConfigManager corrigé

Cette PR résout le problème `Path must not be null` de façon élégante en ajoutant la dépendance manquante et en utilisant `@PostConstruct` proprement.

### 🎯 Approche choisie

Au lieu d'utiliser des contournements (`InitializingBean`), cette solution ajoute directement la dépendance manquante dans le `pom.xml` pour utiliser `@PostConstruct` normalement.

### 🔧 Corrections apportées

#### 1. **Ajout dépendance Jakarta Annotations dans `pom.xml`**
```xml
<!-- Jakarta Annotations (pour @PostConstruct, @PreDestroy, etc.) -->
<dependency>
    <groupId>jakarta.annotation</groupId>
    <artifactId>jakarta.annotation-api</artifactId>
    <version>2.1.1</version>
</dependency>
```

#### 2. **ConfigManager corrigé avec `@PostConstruct`**
- ✅ Import correct : `import jakarta.annotation.PostConstruct;`
- ✅ Constructeur vide (pas de chargement)
- ✅ Méthode `@PostConstruct` pour l'initialisation après injection Spring
- ✅ Protection contre les chemins null dans `loadConfigFile()`
- ✅ Création de configurations vides en cas d'erreur

### 🏗️ Pourquoi Jakarta Annotations ?

Depuis **Java 11**, les annotations `javax.annotation.*` ont été supprimées du JDK :
- ❌ `javax.annotation.PostConstruct` - N'existe plus
- ✅ `jakarta.annotation.PostConstruct` - Nouvelle version standard

Spring Boot 3.x utilise Jakarta EE, donc cette dépendance est la **solution officielle**.

### 🎯 Avantages de cette approche

1. **Standard et propre** - Utilise les annotations officielles Jakarta
2. **Pas de contournement** - Solution directe et élégante 
3. **Compatible futur** - Suit les standards Jakarta EE
4. **Réutilisable** - Autres annotations disponibles (`@PreDestroy`, `@Resource`, etc.)
5. **Léger** - Dépendance de seulement ~50KB

### 🚀 Test

Après merge, l'application devrait démarrer sans erreur :

```bash
# Recompiler avec les nouvelles dépendances
mvn clean compile

# Démarrer en mode test
./angel-launcher.sh start -p test
```

### 📋 Changements techniques

**`pom.xml`** :
- Ajout propriété `jakarta.annotation.version=2.1.1`
- Ajout dépendance `jakarta.annotation-api`

**`ConfigManager.java`** :
- Import `jakarta.annotation.PostConstruct`
- Constructeur vide
- Méthode `init()` avec `@PostConstruct`
- Protection null dans `loadConfigFile()`

Cette solution est **la plus propre et standard** pour résoudre le problème d'initialisation du ConfigManager.